### PR TITLE
Add inlineContainer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ var options = {
 	// interaction point when inline.
 	inlineOffsetX: 0,
 	inlineOffsetY: 0,
+	// A DOM element to append the inline ZoomPane to.
+	inlineContainer: document.body,
 	// Which trigger attribute to pull the ZoomPane image source from.
 	sourceAttribute: 'data-zoom',
 	// How much to magnify the trigger by in the ZoomPane.

--- a/src/js/Drift.js
+++ b/src/js/Drift.js
@@ -31,6 +31,8 @@ module.exports = class Drift {
       // interaction point when inline.
       inlineOffsetX = 0,
       inlineOffsetY = 0,
+      // A DOM element to append the inline ZoomPane to
+      inlineContainer = document.body,
       // Which trigger attribute to pull the ZoomPane image source from.
       sourceAttribute = 'data-zoom',
       // How much to magnify the trigger by in the ZoomPane.
@@ -74,8 +76,11 @@ module.exports = class Drift {
     if (inlinePane !== true && !isDOMElement(paneContainer)) {
       throw new TypeError('`paneContainer` must be a DOM element when `inlinePane !== true`');
     }
+    if(!isDOMElement(inlineContainer)){
+      throw new TypeError('`inlineContainer` must be a DOM element');
+    }
 
-    this.settings = { namespace, showWhitespaceAtEdges, containInline, inlineOffsetX, inlineOffsetY, sourceAttribute, zoomFactor, paneContainer, inlinePane, handleTouch, onShow, onHide, injectBaseStyles, hoverDelay, touchDelay, hoverBoundingBox, touchBoundingBox };
+    this.settings = { namespace, showWhitespaceAtEdges, containInline, inlineOffsetX, inlineOffsetY, inlineContainer, sourceAttribute, zoomFactor, paneContainer, inlinePane, handleTouch, onShow, onHide, injectBaseStyles, hoverDelay, touchDelay, hoverBoundingBox, touchBoundingBox };
 
     if (this.settings.injectBaseStyles) {
       injectBaseStylesheet();
@@ -108,6 +113,7 @@ module.exports = class Drift {
       namespace: this.settings.namespace,
       inlineOffsetX: this.settings.inlineOffsetX,
       inlineOffsetY: this.settings.inlineOffsetY,
+      inlineContainer: this.settings.inlineContainer
     });
   }
 

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -22,10 +22,10 @@ export default class ZoomPane {
       containInline = throwIfMissing(),
       inlineOffsetX = 0,
       inlineOffsetY = 0,
+      inlineContainer = document.body
     } = options;
 
-    this.settings = { container, zoomFactor, inline, namespace, showWhitespaceAtEdges, containInline, inlineOffsetX, inlineOffsetY };
-    this.settings.inlineContainer = document.body;
+    this.settings = { container, zoomFactor, inline, namespace, showWhitespaceAtEdges, containInline, inlineOffsetX, inlineOffsetY, inlineContainer };
 
     this.openClasses = this._buildClasses('open');
     this.openingClasses = this._buildClasses('opening');

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,6 +11,7 @@ export function defaultDriftConfig() {
     containInline: false,
     inlineOffsetX: 0,
     inlineOffsetY: 0,
+    inlineContainer: document.body,
     sourceAttribute: 'data-zoom',
     zoomFactor: 3,
     paneContainer: document.body,
@@ -22,7 +23,7 @@ export function defaultDriftConfig() {
     hoverDelay: 0,
     touchDelay: 0,
     hoverBoundingBox: false,
-    touchBoundingBox: false,
+    touchBoundingBox: false
   };
 }
 


### PR DESCRIPTION
We want to use this library for images loaded inside a modal with a z-index of 1000.
Being able to pass the inlineContainer as an option is the easiest way to reach our goal.