### PR TITLE
Use consistent module format

### DIFF
--- a/src/js/Drift.js
+++ b/src/js/Drift.js
@@ -4,7 +4,7 @@ import injectBaseStylesheet from './injectBaseStylesheet';
 import Trigger from './Trigger';
 import ZoomPane from './ZoomPane';
 
-module.exports = class Drift {
+export default class Drift {
   VERSION = '1.2.0'
 
   constructor(triggerEl, options = {}) {


### PR DESCRIPTION
Can you use export in Drift.js? Mixing module formats causes issues when using webpack to convert modules. The old way didn't present an issue when we used Babel, but webpack appears to be more strict. We switched because webpack can "tree shake" unused modules.