### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,55 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Checklist:**
+
+- [ ] I have checked stackoverflow for this bug and there are no answers or the question does not exist
+- [ ] I have searched through the issue list for related bugs or issues
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+```js
+// A *self-contained* demonstration of the problem follows...
+// This should be able to be dropped into a file with react-imgix installed and just work
+```
+
+[alternatively, link to a codepen]
+
+Steps to reproduce the behaviour:
+
+1.  Go to '...'
+2.  Click on '....'
+3.  Scroll down to '....'
+4.  See error
+
+**Expected behaviour**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Information:**
+
+- drift version: [e.g. v1.0]
+
+**Desktop (please complete the following information):**
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,19 +37,7 @@ If applicable, add screenshots to help explain your problem.
 **Information:**
 
 - drift version: [e.g. v1.0]
-
-**Desktop (please complete the following information):**
-
-- OS: [e.g. iOS]
-- Browser [e.g. chrome, safari]
-- Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
-
-- Device: [e.g. iPhone6]
-- OS: [e.g. iOS8.1]
-- Browser [e.g. stock browser, safari]
-- Version [e.g. 22]
+- browser version: [include link from [https://www.whatsmybrowser.org/](https://www.whatsmybrowser.org/) or details about the OS used and browser version]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ about: Create a report to help us improve
 A clear and concise description of what the bug is. Please strive to reach the **root problem** of your issue to avoid the XY problem. See more: https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem
 
 **To Reproduce**
-A bug is a _demonstrable problem_ that is scause by the code in the repository. Thus, the contributors need a way to reproduce your issue - if we can't reproduce your issue, we can't help you! Also, please be as detailed as possible!
+A bug is a _demonstrable problem_ that is caused by the code in the repository. Thus, the contributors need a way to reproduce your issue - if we can't reproduce your issue, we can't help you! Also, please be as detailed as possible.
 
 [a link to a codepen; here is a link to a codepen with drift installed which can be forked: https://codepen.io/imgix/pen/WrRmLb]
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,22 +4,25 @@ about: Create a report to help us improve
 
 ---
 
-**Checklist:**
+**Before you submit:**
 
-- [ ] I have checked stackoverflow for this bug and there are no answers or the question does not exist
-- [ ] I have searched through the issue list for related bugs or issues
+- [ ] Please search through the existing issues (both open AND closed) to see if your issue has been discussed before. Github issue search can be used for this: https://github.com/imgix/drift/issues?utf8=%E2%9C%93&q=is%3Aissue
+- [ ] Please ensure the problem has been isolated and reduced. This link explains more: http://css-tricks.com/6263-reduced-test-cases/
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is. Please strive to reach the **root problem** of your issue to avoid the XY problem. See more: https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem
 
 **To Reproduce**
+A bug is a _demonstrable problem_ that is scause by the code in the repository. Thus, the contributors need a way to reproduce your issue - if we can't reproduce your issue, we can't help you! Also, please be as detailed as possible!
+
+[a link to a codepen; here is a link to a codepen with drift installed which can be forked: https://codepen.io/imgix/pen/WrRmLb]
+
+[alternatively, please provide a code example]
 
 ```js
 // A *self-contained* demonstration of the problem follows...
 // This should be able to be dropped into a file with react-imgix installed and just work
 ```
-
-[alternatively, link to a codepen]
 
 Steps to reproduce the behaviour:
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ about: Suggest an idea for this project
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+A clear and concise description of how this feature would function.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,9 +4,10 @@ about: Suggest an idea for this project
 
 ---
 
-**Checklist:**
+**Before you submit:**
 
-- [ ] I have searched through the issue list for related requests or issues
+- [ ] Please search through the existing issues (both open AND closed) to see if your feature has already been discussed. Github issue search can be used for this: https://github.com/imgix/drift/issues?utf8=%E2%9C%93&q=is%3Aissue
+- [ ] Please take a moment to find out whether your idea fits with the scope and aims of the project
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Checklist:**
+
+- [ ] I have searched through the issue list for related requests or issues
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,13 +1,12 @@
 ---
 name: Question
-about: Ask a Question about the project
+about: Ask a question about the project
 
 ---
 
-**Checklist:**
+**Before you submit:**
 
-- [ ] I have checked stackoverflow for this question and there are no answers or the question does not exist
-- [ ] I have searched through the issue list for related questions or issues
+- [ ] Please search through the existing issues (both open AND closed) to see if your question has already been discussed. Github issue search can be used for this: https://github.com/imgix/drift/issues?utf8=%E2%9C%93&q=is%3Aissue
 
 **Question**
 A clear and concise description of your question

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question
+about: Ask a Question about the project
+
+---
+
+**Checklist:**
+
+- [ ] I have checked stackoverflow for this question and there are no answers or the question does not exist
+- [ ] I have searched through the issue list for related questions or issues
+
+**Question**
+A clear and concise description of your question

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,7 +39,7 @@ _To help the project's maintainers and community to quickly understand the natur
 
 ## Checklist
 
-Please use the checklist that is most closely related to your pr _(you only need to use one checklist, and you can skip items that aren't applicable or don't make sense)_:
+Please use the checklist that is most closely related to your PR _(you only need to use one checklist, and you can skip items that aren't applicable or don't make sense)_:
 
 - [fixing typos]()
 - [documentation]()
@@ -49,12 +49,12 @@ Please use the checklist that is most closely related to your pr _(you only need
 
 ### Fixing typos
 
-- [ ] The PR title is in the conventional commit format: e.g. `chore(readme): fixed typo`
-- [ ] Add your to the [contributors](#packagejson-contributors) array in package.json!
+- [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `chore(readme): fixed typo`
+- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ### Documentation
 
-- [ ] The PR title is in the conventional commit format: e.g. `chore(readme): updated documentation for ___`
+- [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `chore(readme): updated documentation for ___`
 - [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ### Bug Fix
@@ -64,17 +64,17 @@ Please use the checklist that is most closely related to your pr _(you only need
 - [ ] Update the readme
 - [ ] Update or add any necessary API documentation
 - [ ] Add some [steps](#steps-to-test) so we can test your bug fix
-- [ ] The PR title is in the conventional commit format: e.g. `fix(<area>): fixed bug #issue-number`
+- [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
 - [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ### New Feature
 
-- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your pr might not be accepted.
+- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
 - [ ] Run unit tests to ensure all existing tests are still passing
 - [ ] Add new passing unit tests to cover the code introduced by your pr
 - [ ] Update the readme
 - [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
-- [ ] The PR title is in the conventional commit format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
+- [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
 - [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ## Steps to Test
@@ -123,8 +123,8 @@ full name <email@address.com> (https://website.com)
 {
   "name": "drift",
   "contributors": [
-    "Brian Woodward <jon.schlinkert@sellside.com> (https://github.com/jonschlinkert)",
-    "Jon Schlinkert <brian.woodward@sellside.com> (https://github.com/doowb)"
+    "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
+    "Jon Smith <jon.smith@jonsmith.com> (https://github.com/jonsmith)"
   ]
 }
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,8 @@ Hello, and thanks for contributing to drift! 🎉🙌
 
 There are three main goals in this document, depending on the nature of your pr:
 
-- [description](#description): please tell us about your pr
-- [checklist](#checklist): please review the checklist that is most closly related to your pr
+- [description](#description): please tell us about your PR
+- [checklist](#checklist): please review the checklist that is most closly related to your PR
 - [contributors list](#packagejson-contributors): you're one of us now, please add yourself to `package.json` and let the world know!
 
 The following sections provide more detail on each.
@@ -42,7 +42,7 @@ delete everything above this line
 
 _To help the project's maintainers and community to quickly understand the nature of your pull requeset, please create a description that incorporates the following elements:_
 
-- [] what is accomplished by the pr
+- [] what is accomplished by the PR
 - [] if there is something potentially controversial in your pr, please take a moment to tell us about your choices
 
 ## Checklist
@@ -68,7 +68,7 @@ Please use the checklist that is most closely related to your PR _(you only need
 ### Bug Fix
 
 - [ ] All existing unit tests are still passing (if applicable)
-- [ ] Add new passing unit tests to cover the code introduced by your pr
+- [ ] Add new passing unit tests to cover the code introduced by your PR
 - [ ] Update the readme
 - [ ] Update or add any necessary API documentation
 - [ ] Add some [steps](#steps-to-test) so we can test your bug fix
@@ -79,7 +79,7 @@ Please use the checklist that is most closely related to your PR _(you only need
 
 - [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
 - [ ] Run unit tests to ensure all existing tests are still passing
-- [ ] Add new passing unit tests to cover the code introduced by your pr
+- [ ] Add new passing unit tests to cover the code introduced by your PR
 - [ ] Update the readme
 - [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
 - [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- prettier-ignore-start -->
 Hello, and thanks for contributing to drift! 🎉🙌
 
 **Before submitting a pull request,** please make sure the following is done:
@@ -10,11 +11,6 @@ Hello, and thanks for contributing to drift! 🎉🙌
 6.  Fill out the template below and delete everything above the line.
 
 **Learn more about contributing:** https://github.com/imgix/drift/blob/master/CONTRIBUTING.md
-
-<!--
-DELETE EVERYTHING ABOVE THIS LINE
--------------------------------------------
--->
 
 ## tldr
 
@@ -29,6 +25,18 @@ The following sections provide more detail on each.
 **Improve this document**
 
 Please don't hesitate to [ask questions][issues] for clarification, or to [make suggestions][issues] (or a pull request) to improve this document.
+
+
+
+
+
+delete everything above this line
+-------------------------------------------
+
+
+
+
+
 
 ## Description
 
@@ -98,6 +106,18 @@ Steps:
 3.  Scroll down to '....'
 4.  See that the error has been fixed
 
+
+
+
+
+delete everything below this line
+-------------------------------------------
+
+
+
+
+
+
 ## Conventional Commit Spec
 
 PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`
@@ -110,10 +130,10 @@ PR titles should be in the format `<type>(<scope>): <description>`. For example:
 
 **Add yourself!**
 
-When adding your information to the `contributors` array in package.json, please use the following format (provide your name at minimum, the other fields are optional):
+When adding your information to the `contributors` array in package.json, please use the following format (provide your name or username at minimum, the other fields are optional):
 
 ```
-full name <email@address.com> (https://website.com)
+full name or username <email@address.com> (https://website.com)
 ```
 
 **Example**
@@ -124,9 +144,11 @@ full name <email@address.com> (https://website.com)
   "name": "drift",
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
-    "Jon Smith <jon.smith@jonsmith.com> (https://github.com/jonsmith)"
+    "Jon Smith <jon.smith@jonsmith.com> (https://github.com/jonsmith)",
+    "helenjones"
   ]
 }
 ```
 
 [issues]: ../../issues
+<!-- prettier-ignore-end -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,10 @@ Hello, and thanks for contributing to drift! 🎉🙌
 
 ## tldr
 
-There are three main goals in this document, depending on the nature of your pr:
+There are three main goals in this document, depending on the nature of your PR:
 
 - [description](#description): please tell us about your PR
-- [checklist](#checklist): please review the checklist that is most closly related to your PR
+- [checklist](#checklist): please review the checklist that is most closely related to your PR
 - [contributors list](#packagejson-contributors): you're one of us now, please add yourself to `package.json` and let the world know!
 
 The following sections provide more detail on each.
@@ -40,7 +40,7 @@ delete everything above this line
 
 ## Description
 
-_To help the project's maintainers and community to quickly understand the nature of your pull requeset, please create a description that incorporates the following elements:_
+_To help the project's maintainers and community to quickly understand the nature of your pull request, please create a description that incorporates the following elements:_
 
 - [] what is accomplished by the PR
 - [] if there is something potentially controversial in your pr, please take a moment to tell us about your choices
@@ -122,15 +122,15 @@ delete everything below this line
 
 PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`
 
-`type` can be one of `feat`, `fix`, `test`, or `chore`
+`type` can be one of `feat`, `fix`, `test`, or `chore`.
 `scope` is optional, and can be anything.
-`description` should be a short description of the change, in past tense
+`description` should be a short description of the change, in past tense.
 
 ## package.json contributors
 
 **Add yourself!**
 
-When adding your information to the `contributors` array in package.json, please use the following format (provide your name or username at minimum, the other fields are optional):
+When adding your information to the `contributors` array in package.json, please use the following format (provide your name or username at a minimum, the other fields are optional):
 
 ```
 full name or username <email@address.com> (https://website.com)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,132 @@
+Hello, and thanks for contributing to drift! 🎉🙌
+
+**Before submitting a pull request,** please make sure the following is done:
+
+1.  Fork [the repository](https://github.com/imgix/drift) and create your branch from `master`.
+2.  Run `npm install` in the repository root.
+3.  If you've fixed a bug or added code that should be tested, add tests!
+4.  Ensure the test suite passes (`npm run test`). Tip: `npm run --watch` is helpful in development.
+5.  Format your code with [prettier](https://github.com/prettier/prettier) (`npm run format`). Don't worry too much if you haven't done this, we have a bot that will do this for you when you submit a PR.
+6.  Fill out the template below and delete everything above the line.
+
+**Learn more about contributing:** https://github.com/imgix/drift/blob/master/CONTRIBUTING.md
+
+<!--
+DELETE EVERYTHING ABOVE THIS LINE
+-------------------------------------------
+-->
+
+## tldr
+
+There are three main goals in this document, depending on the nature of your pr:
+
+- [description](#description): please tell us about your pr
+- [checklist](#checklist): please review the checklist that is most closly related to your pr
+- [contributors list](#packagejson-contributors): you're one of us now, please add yourself to `package.json` and let the world know!
+
+The following sections provide more detail on each.
+
+**Improve this document**
+
+Please don't hesitate to [ask questions][issues] for clarification, or to [make suggestions][issues] (or a pull request) to improve this document.
+
+## Description
+
+_To help the project's maintainers and community to quickly understand the nature of your pull requeset, please create a description that incorporates the following elements:_
+
+- [] what is accomplished by the pr
+- [] if there is something potentially controversial in your pr, please take a moment to tell us about your choices
+
+## Checklist
+
+Please use the checklist that is most closely related to your pr _(you only need to use one checklist, and you can skip items that aren't applicable or don't make sense)_:
+
+- [fixing typos]()
+- [documentation]()
+- [bug fix]()
+- [new feature]()
+- [other]()
+
+### Fixing typos
+
+- [ ] The PR title is in the conventional commit format: e.g. `chore(readme): fixed typo`
+- [ ] Add your to the [contributors](#packagejson-contributors) array in package.json!
+
+### Documentation
+
+- [ ] The PR title is in the conventional commit format: e.g. `chore(readme): updated documentation for ___`
+- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
+
+### Bug Fix
+
+- [ ] All existing unit tests are still passing (if applicable)
+- [ ] Add new passing unit tests to cover the code introduced by your pr
+- [ ] Update the readme
+- [ ] Update or add any necessary API documentation
+- [ ] Add some [steps](#steps-to-test) so we can test your bug fix
+- [ ] The PR title is in the conventional commit format: e.g. `fix(<area>): fixed bug #issue-number`
+- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
+
+### New Feature
+
+- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your pr might not be accepted.
+- [ ] Run unit tests to ensure all existing tests are still passing
+- [ ] Add new passing unit tests to cover the code introduced by your pr
+- [ ] Update the readme
+- [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
+- [ ] The PR title is in the conventional commit format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
+- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
+
+## Steps to Test
+
+_A code example or a set of steps is preferred._
+
+Related issue: [e.g. #42]
+
+Code:
+
+```js
+// A standalone JS example of what the PR solves
+```
+
+A link to a codepen is also an option.
+
+Steps:
+
+1.  Go to '...'
+2.  Click on '....'
+3.  Scroll down to '....'
+4.  See that the error has been fixed
+
+## Conventional Commit Spec
+
+PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`
+
+`type` can be one of `feat`, `fix`, `test`, or `chore`
+`scope` is optional, and can be anything.
+`description` should be a short description of the change, in past tense
+
+## package.json contributors
+
+**Add yourself!**
+
+When adding your information to the `contributors` array in package.json, please use the following format (provide your name at minimum, the other fields are optional):
+
+```
+full name <email@address.com> (https://website.com)
+```
+
+**Example**
+
+```json
+// -- package.json --
+{
+  "name": "drift",
+  "contributors": [
+    "Brian Woodward <jon.schlinkert@sellside.com> (https://github.com/jonschlinkert)",
+    "Jon Schlinkert <brian.woodward@sellside.com> (https://github.com/doowb)"
+  ]
+}
+```
+
+[issues]: ../../issues

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,7 +53,6 @@ Please use the checklist that is most closely related to your PR _(you only need
 - [documentation]()
 - [bug fix]()
 - [new feature]()
-- [other]()
 
 ### Fixing typos
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,8 @@ patches and features.
 ## Using the issue tracker
 
 The issue tracker is the preferred channel for [bug reports](#bugs),
-[features requests](#features) and [submitting pull
+[features requests](#features), questions, and [submitting pull
 requests](#pull-requests), but please respect the following restrictions:
-
-- Please **do not** use the issue tracker for personal support requests (use
-  [Stack Overflow](http://stackoverflow.com) or IRC).
 
 - Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "drift-zoom",
   "version": "1.2.0",
   "description": "Easily add \"zoom on hover\" functionality to your site's images. Lightweight, no-dependency JavaScript.",
+  "contributors": [
+    "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)"
+  ],
   "main": "dist/Drift.js",
   "scripts": {
     "format": "prettier --write \"{src,test}/**/*.js\"",


### PR DESCRIPTION
## Description
PR and issues templates help guide users to create better issues and PRs, which help contributors maintain the repo.

### Documentation

- [x] The PR title is in the conventional commit format: e.g. `chore(readme): updated documentation for ___`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

[issues]: ../../issues
