### PR TITLE
fix(zoom-pane): set min and max values correctly when image is smaller than container

### DIFF
--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -96,6 +96,7 @@ export default class ZoomPane {
     const differenceBetweenContainerHeightAndImgHeight = elHeight - imgElHeight;
     const isContainerLargerThanImgX = differenceBetweenContainerWidthAndImgWidth > 0;
     const isContainerLargerThanImgY = differenceBetweenContainerHeightAndImgHeight > 0;
+    
     const minLeft = isContainerLargerThanImgX ? differenceBetweenContainerWidthAndImgWidth / 2 : 0;
     const minTop = isContainerLargerThanImgY ? differenceBetweenContainerHeightAndImgHeight / 2 : 0;
 

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -96,7 +96,7 @@ export default class ZoomPane {
     const differenceBetweenContainerHeightAndImgHeight = elHeight - imgElHeight;
     const isContainerLargerThanImgX = differenceBetweenContainerWidthAndImgWidth > 0;
     const isContainerLargerThanImgY = differenceBetweenContainerHeightAndImgHeight > 0;
-    
+
     const minLeft = isContainerLargerThanImgX ? differenceBetweenContainerWidthAndImgWidth / 2 : 0;
     const minTop = isContainerLargerThanImgY ? differenceBetweenContainerHeightAndImgHeight / 2 : 0;
 

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -80,10 +80,31 @@ export default class ZoomPane {
   // `percentageOffsetX` and `percentageOffsetY` must be percentages
   // expressed as floats between `0' and `1`.
   setPosition(percentageOffsetX, percentageOffsetY, triggerRect) {
-    let left = -(this.imgEl.clientWidth * percentageOffsetX - this.el.clientWidth / 2);
-    let top = -(this.imgEl.clientHeight * percentageOffsetY - this.el.clientHeight / 2);
-    let maxLeft = -(this.imgEl.clientWidth - this.el.clientWidth);
-    let maxTop = -(this.imgEl.clientHeight - this.el.clientHeight);
+    const { width: imgElWidth, height: imgElHeight } = this.imgEl.getBoundingClientRect();
+    const { width: elWidth, height: elHeight } = this.el.getBoundingClientRect();
+
+    const centreOfContainerX = elWidth / 2;
+    const centreOfContainerY = elHeight / 2;
+
+    const targetImgXToBeCentre = imgElWidth * percentageOffsetX;
+    const targetImgYToBeCentre = imgElHeight * percentageOffsetY;
+
+    let left = centreOfContainerX - targetImgXToBeCentre;
+    let top = centreOfContainerY - targetImgYToBeCentre;
+
+    const differenceBetweenContainerWidthAndImgWidth = elWidth - imgElWidth;
+    const differenceBetweenContainerHeightAndImgHeight = elHeight - imgElHeight;
+    const isContainerLargerThanImgX = differenceBetweenContainerWidthAndImgWidth > 0;
+    const isContainerLargerThanImgY = differenceBetweenContainerHeightAndImgHeight > 0;
+    const minLeft = isContainerLargerThanImgX ? differenceBetweenContainerWidthAndImgWidth / 2 : 0;
+    const minTop = isContainerLargerThanImgY ? differenceBetweenContainerHeightAndImgHeight / 2 : 0;
+
+    const maxLeft = isContainerLargerThanImgX
+      ? differenceBetweenContainerWidthAndImgWidth / 2
+      : differenceBetweenContainerWidthAndImgWidth;
+    const maxTop = isContainerLargerThanImgY
+      ? differenceBetweenContainerHeightAndImgHeight / 2
+      : differenceBetweenContainerHeightAndImgHeight;
 
     if (this.el.parentElement === this.settings.inlineContainer) {
       // This may be needed in the future to deal with browser event
@@ -94,31 +115,21 @@ export default class ZoomPane {
       let scrollY = window.pageYOffset;
 
       let inlineLeft =
-        triggerRect.left +
-        percentageOffsetX * triggerRect.width -
-        this.el.clientWidth / 2 +
-        this.settings.inlineOffsetX +
-        scrollX;
+        triggerRect.left + percentageOffsetX * triggerRect.width - elWidth / 2 + this.settings.inlineOffsetX + scrollX;
       let inlineTop =
-        triggerRect.top +
-        percentageOffsetY * triggerRect.height -
-        this.el.clientHeight / 2 +
-        this.settings.inlineOffsetY +
-        scrollY;
+        triggerRect.top + percentageOffsetY * triggerRect.height - elHeight / 2 + this.settings.inlineOffsetY + scrollY;
 
       if (this.settings.containInline) {
-        let elRect = this.el.getBoundingClientRect();
-
         if (inlineLeft < triggerRect.left + scrollX) {
           inlineLeft = triggerRect.left + scrollX;
-        } else if (inlineLeft + this.el.clientWidth > triggerRect.left + triggerRect.width + scrollX) {
-          inlineLeft = triggerRect.left + triggerRect.width - this.el.clientWidth + scrollX;
+        } else if (inlineLeft + elWidth > triggerRect.left + triggerRect.width + scrollX) {
+          inlineLeft = triggerRect.left + triggerRect.width - elWidth + scrollX;
         }
 
         if (inlineTop < triggerRect.top + scrollY) {
           inlineTop = triggerRect.top + scrollY;
-        } else if (inlineTop + this.el.clientHeight > triggerRect.top + triggerRect.height + scrollY) {
-          inlineTop = triggerRect.top + triggerRect.height - this.el.clientHeight + scrollY;
+        } else if (inlineTop + elHeight > triggerRect.top + triggerRect.height + scrollY) {
+          inlineTop = triggerRect.top + triggerRect.height - elHeight + scrollY;
         }
       }
 
@@ -127,14 +138,14 @@ export default class ZoomPane {
     }
 
     if (!this.settings.showWhitespaceAtEdges) {
-      if (left > 0) {
-        left = 0;
+      if (left > minLeft) {
+        left = minLeft;
       } else if (left < maxLeft) {
         left = maxLeft;
       }
 
-      if (top > 0) {
-        top = 0;
+      if (top > minTop) {
+        top = minTop;
       } else if (top < maxTop) {
         top = maxTop;
       }


### PR DESCRIPTION
## Description

In the past there was an issue where if the zoomed image's width was smaller than the width of the zoomed image's container, the image would jump around the container when panning around the image. This is shown here #65. 

This PR updates the positioning logic of the zoom pane to ensure that the image is rendered correctly in both situations (when the image is smaller than the container, and when it is bigger).

- when image is smaller: the image is centred in the container
- when image is larger: behaviour is unchanged

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

![driftfixed](https://user-images.githubusercontent.com/615334/42425807-e6636ab8-8375-11e8-9bca-5ba9a32b1df4.gif)
