### PR TITLE
fix: export Drift's public API

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 		</div>
 	</div>
 
-	<script src="dist/Drift.min.js"></script>
+	<script src="dist/Drift.js"></script>
 	<script>
 		new Drift(document.querySelector('.drift-demo-trigger'), {
 			paneContainer: document.querySelector('.detail'),

--- a/src/js/Drift.js
+++ b/src/js/Drift.js
@@ -171,3 +171,22 @@ export default class Drift {
     this.trigger._unbindEvents();
   }
 }
+
+// Public API
+Object.defineProperty(Drift.prototype, "isShowing", {
+  get: function() {
+    return this.isShowing;
+  }
+});
+Object.defineProperty(Drift.prototype, "zoomFactor", {
+  get: function() {
+    return this.zoomFactor;
+  },
+  set: function(value) {
+    this.zoomFactor = value;
+  }
+});
+Drift.prototype["setZoomImageURL"] = Drift.prototype.setZoomImageURL;
+Drift.prototype["disable"] = Drift.prototype.disable;
+Drift.prototype["enable"] = Drift.prototype.enable;
+Drift.prototype["destroy"] = Drift.prototype.destroy;


### PR DESCRIPTION
## Description

This PR uses [the approach preferred by the Closure docs](https://developers.google.com/closure/compiler/docs/api-tutorial3#export) to export the public API of the Drift class. This has to happen because Closure rewrites the names of the class methods, which prevents third-parties from calling methods by their proper names.

Fixes #81 

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Steps:

1.  Clone this PR, `npm install`
2. 	Run `npm run build:watch`
2.	Play around with drift in `index.html`. `console.log(new Drift(...))` should show that everything is exported on the prototype.

