### PR TITLE
fix: stop loupe being shown in incorrect position on mouseenter

### DIFF
--- a/src/js/BoundingBox.js
+++ b/src/js/BoundingBox.js
@@ -59,8 +59,6 @@ export default class BoundingBox {
     let inlineLeft = triggerRect.left + percentageOffsetX * triggerRect.width - this.el.clientWidth / 2 + pageXOffset;
     let inlineTop = triggerRect.top + percentageOffsetY * triggerRect.height - this.el.clientHeight / 2 + pageYOffset;
 
-    let elRect = this.el.getBoundingClientRect();
-
     if (inlineLeft < triggerRect.left + pageXOffset) {
       inlineLeft = triggerRect.left + pageXOffset;
     } else if (inlineLeft + this.el.clientWidth > triggerRect.left + triggerRect.width + pageXOffset) {

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -121,16 +121,6 @@ export default class ZoomPane {
       let scrollX = window.pageXOffset;
       let scrollY = window.pageYOffset;
 
-      console.log(
-        "triggerRect.left, percentageOffsetX, triggerRect.width, elWidth / 2, this.settings.inlineOffsetX, scrollX",
-        triggerRect.left,
-        percentageOffsetX,
-        triggerRect.width,
-        elWidth / 2,
-        this.settings.inlineOffsetX,
-        scrollX
-      );
-
       let inlineLeft =
         triggerRect.left + percentageOffsetX * triggerRect.width - elWidth / 2 + this.settings.inlineOffsetX + scrollX;
       let inlineTop =
@@ -150,7 +140,6 @@ export default class ZoomPane {
         }
       }
 
-      console.log("inlineLeft", inlineLeft);
       this.el.style.left = `${inlineLeft}px`;
       this.el.style.top = `${inlineTop}px`;
     }

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -84,8 +84,10 @@ export default class ZoomPane {
   // `percentageOffsetX` and `percentageOffsetY` must be percentages
   // expressed as floats between `0' and `1`.
   setPosition(percentageOffsetX, percentageOffsetY, triggerRect) {
-    const { width: imgElWidth, height: imgElHeight } = this.imgEl.getBoundingClientRect();
-    const { width: elWidth, height: elHeight } = this.el.getBoundingClientRect();
+    const imgElWidth = this.imgEl.offsetWidth;
+    const imgElHeight = this.imgEl.offsetHeight;
+    const elWidth = this.el.offsetWidth;
+    const elHeight = this.el.offsetHeight;
 
     const centreOfContainerX = elWidth / 2;
     const centreOfContainerY = elHeight / 2;
@@ -119,6 +121,16 @@ export default class ZoomPane {
       let scrollX = window.pageXOffset;
       let scrollY = window.pageYOffset;
 
+      console.log(
+        "triggerRect.left, percentageOffsetX, triggerRect.width, elWidth / 2, this.settings.inlineOffsetX, scrollX",
+        triggerRect.left,
+        percentageOffsetX,
+        triggerRect.width,
+        elWidth / 2,
+        this.settings.inlineOffsetX,
+        scrollX
+      );
+
       let inlineLeft =
         triggerRect.left + percentageOffsetX * triggerRect.width - elWidth / 2 + this.settings.inlineOffsetX + scrollX;
       let inlineTop =
@@ -138,6 +150,7 @@ export default class ZoomPane {
         }
       }
 
+      console.log("inlineLeft", inlineLeft);
       this.el.style.left = `${inlineLeft}px`;
       this.el.style.top = `${inlineTop}px`;
     }


### PR DESCRIPTION
## Description

This library had an issue where if the mouse was quickly moved into the container and stopped, the loupe would be incorrectly positioned.

This was because the internal code was using `getBoundingClientRect` to calculate the width of the zoom pane, which was changing during the mouseenter animation. This animation was using CSS transforms to change the apparent width of the zoom pane. This caused the positioning logic to incorrectly position the image, and the loupe container.

This PR fixes this by using `offsetWidth` and `offsetHeight` instead, which aren't affected by transforms.

The issue: 
![loupebug](https://user-images.githubusercontent.com/615334/47935566-a7720000-df3f-11e8-9808-aff4ca52b5c7.gif)

After solution:
![loupefixed](https://user-images.githubusercontent.com/615334/47935570-ae990e00-df3f-11e8-867d-2a02b822cef8.gif)


This fixes #86.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

To test this PR:

1. Clone this PR, and run `npm install && npm run build`. 
2. Update the `new Drift(...)` part in index.html to the snippet below to make the bug easier to reproduce.
3. Then, run a webserver in the root of the project. I use browser-sync for this `browser-sync start --server --files "dist/*"`.
4. Observe that when the mouse is quickly moved over the image, and then stopped, that the loupe is initially positioned incorrectly.
5. Checkout this PR's branch
6. Observe that the loupe is no longer positioned incorrectly.

Code snippet to change relevant part index.html to:
```js
		new Drift(document.querySelector('.drift-demo-trigger'), {
			paneContainer: document.querySelector('.detail'),
			hoverDelay: 200, // make this longer to make the problem more obvious
			zoomFactor: 2,
			inlinePane: true,
		});
```