### PR TITLE
fix: Drift not hiding if shown when destroyed

### DIFF
--- a/src/js/Drift.js
+++ b/src/js/Drift.js
@@ -168,6 +168,7 @@ export default class Drift {
   }
 
   destroy() {
+    this.trigger._hide();
     this.trigger._unbindEvents();
   }
 }

--- a/src/js/Trigger.js
+++ b/src/js/Trigger.js
@@ -121,7 +121,9 @@ export default class Trigger {
   }
 
   _hide(e) {
-    e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
 
     this._lastMovement = null;
 

--- a/test/testDrift.js
+++ b/test/testDrift.js
@@ -1,4 +1,4 @@
-/* global describe it expect beforeEach afterEach */
+/* global describe it expect beforeEach afterEach spyOn */
 
 import Drift from "../src/js/Drift";
 

--- a/test/testDrift.js
+++ b/test/testDrift.js
@@ -137,5 +137,20 @@ describe("Drift", () => {
         expect(drift.trigger.enabled).toBe(false);
       });
     });
+
+    describe("#destroy", () => {
+      it("should hide and unbind events", function() {
+        const anchor = document.querySelector(".test-anchor");
+        const drift = new Drift(anchor);
+
+        const hideSpy = spyOn(drift.trigger, "_hide");
+        const unbindEventsSpy = spyOn(drift.trigger, "_unbindEvents");
+
+        drift.destroy();
+
+        expect(hideSpy).toHaveBeenCalled();
+        expect(unbindEventsSpy).toHaveBeenCalled();
+      });
+    });
   });
 });


### PR DESCRIPTION
Breaking change?: *NO*
Fixes #60 

## Description

If Drift is shown when `destroy` is called, the events get unbound but elements don't get hidden. This results in unresponsive visual elements that hang around.

This fixes the issue by calling `_hide` on the trigger object.

## Checklist

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme _(n/a?)_
- [ ] Update or add any necessary API documentation  _(n/a?)_
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [ ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

1. Set up Drift
2. Hover over target element
3. Call `destroy` (e.g. on a `setTimeout` for testing)
4. See that Drift's elements are hidden properly.
