### PR TITLE
cleanup: simplify linter globals setup for tests

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/test/testBoundingBox.js
+++ b/test/testBoundingBox.js
@@ -1,5 +1,3 @@
-/* global describe it expect */
-
 import BoundingBox from "../src/js/BoundingBox";
 
 import { boundingBoxOptions } from "./helpers";

--- a/test/testDrift.js
+++ b/test/testDrift.js
@@ -1,5 +1,3 @@
-/* global describe it expect beforeEach afterEach spyOn */
-
 import Drift from "../src/js/Drift";
 
 import { defaultDriftConfig } from "./helpers";

--- a/test/testTrigger.js
+++ b/test/testTrigger.js
@@ -1,5 +1,3 @@
-/* global describe it expect beforeEach afterEach */
-
 import Trigger from "../src/js/Trigger";
 
 import { mockEvent, triggerOptions } from "./helpers";

--- a/test/testZoomPane.js
+++ b/test/testZoomPane.js
@@ -1,5 +1,3 @@
-/* global describe it expect */
-
 import ZoomPane from "../src/js/ZoomPane";
 
 import { zoomPaneOptions } from "./helpers";


### PR DESCRIPTION
Breaking change?: _NO_

## Description

The current setup requires manual management of Jasmine globals in each spec file. This can get cumbersome with time and is easy to forget. This PR addresses that by adding an `.eslintrc.json` file to the test directory that will be merged with the root's settings and specifies that we are using the Jasmine environment so that ESLint can automatically apply the necessary globals.

## Checklist

- [x] All existing unit tests are still passing (if applicable)
- [x] Linting still functions as expected

## Steps to Test

Run ESLint and see that tests are still linted properly: `npm run lint`