### PR TITLE
docs: update badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ![imgix logo](https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=200&h=200)
 
 # Drift 
+[![npm](https://img.shields.io/npm/dm/drift-zoom.svg)](https://www.npmjs.com/package/drift-zoom)
 [![Build Status](https://travis-ci.org/imgix/drift.svg?branch=master)](https://travis-ci.org/imgix/drift)
+[![npm version](https://img.shields.io/npm/v/drift-zoom.svg)](https://www.npmjs.com/package/drift-zoom)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 
 Easily add "zoom on hover" functionality to your site's images. Lightweight, no-dependency JavaScript.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![imgix logo](https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=200&h=200)
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 
-# Drift [![Build Status](https://travis-ci.org/imgix/drift.svg?branch=master)](https://travis-ci.org/imgix/drift)
+# Drift 
+[![Build Status](https://travis-ci.org/imgix/drift.svg?branch=master)](https://travis-ci.org/imgix/drift)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 
 Easily add "zoom on hover" functionality to your site's images. Lightweight, no-dependency JavaScript.
 


### PR DESCRIPTION
Reformats and adds to the badges on our documentation:
- Monthly download stats from npm
- Current version from npm
- Prettier badge
- Moves all badges below the title line