### PR TITLE
refactor: favor directly modifying DOM attributes over using `setAttribute()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:js:dist:prod": "webpack --env build && cp dist/Drift.min.js dist/Drift.js",
     "build:js:lib:commonjs": "cross-env BABEL_ENV=commonjs babel src/js --out-dir lib --source-maps",
     "build:js:lib:es": "cross-env BABEL_ENV=es babel src/js --out-dir es --source-maps",
-    "build:watch": "webpack --progress --colors --watch --env dev",
+    "build:watch": "webpack --progress --color --watch --env dev",
     "clean": "rimraf lib es dist",
     "dev": "npm run build:watch",
     "format:check": "prettier --list-different \"{src,test}/**/*.js\"",

--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -242,7 +242,7 @@ export default class ZoomPane {
     removeClasses(this.el, this.closingClasses);
     removeClasses(this.el, this.inlineClasses);
 
-    this.el.setAttribute("style", "");
+    this.el.style = "";
 
     // The window could have been resized above or below `inline`
     // limits since the ZoomPane was shown. Because of this, we

--- a/src/js/injectBaseStylesheet.js
+++ b/src/js/injectBaseStylesheet.js
@@ -57,10 +57,11 @@ export default function injectBaseStylesheet() {
 
   const styleEl = document.createElement("style");
   styleEl.type = "text/css";
-  styleEl.classList.add("drift-base-styles");
+  styleEl.classList = "drift-base-styles";
 
-  styleEl.appendChild(document.createTextNode(RULES));
-
+  styleEl.textContent = RULES;
   const head = document.head;
-  head.insertBefore(styleEl, head.firstChild);
+
+  const allHeadElements = head.getElementsByTagName("*");
+  allHeadElements.innerHTML = styleEl + allHeadElements.innerHTML;
 }


### PR DESCRIPTION
According to https://stackoverflow.com/a/57633533: `setAttribute()` invokes the HTML parser, which can trigger a CSP violation.
This PR refactors style element construction/manipulation to not leverage `setAttribute()`, where applicable.

See comparison of this behavior between the main branch and this one:

https://user-images.githubusercontent.com/15919091/108142643-027d8180-707b-11eb-94e0-67fdeffa2567.mov

Fixes #595 