### PR TITLE
fix(injectBaseStylesheet): address style injection issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,139 +1,149 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-	<meta name="designer" content="imgix">
-	<meta name="developer" content="imgix">
-	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,maximum-scale=1">
-	<!-- If CSP style policies, ensure SHA, nonce, or unsafe-inline are enabled -->
-	<meta http-equiv="Accept-CH" content="DPR, Width, Viewport-Width">
-	    <meta
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="designer" content="imgix" />
+    <meta name="developer" content="imgix" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,maximum-scale=1" />
+    <meta http-equiv="Accept-CH" content="DPR, Width, Viewport-Width" />
+    <!-- If CSP style policies, ensure SHA, nonce, or unsafe-inline are enabled -->
+    <meta
       http-equiv="Content-Security-Policy"
-      content="style-src 'self' 'sha256-W+PadZMOYbQi3EzR/NC+KcPx3bNLCz0OtfWwp+LK9b4=' 'sha256-OdI56ZW769BKGaLghLr3uZVaaWfqyRwyccMiu8gXf0w=' 'sha256-W+PadZMOYbQi3EzR/NC+KcPx3bNLCz0OtfWwp+LK9b4=' 'sha256-cG/+JJX3ZZs6snnMipxMnaYWATXBcyQw3vFWJF1zmAM='"
+      content="style-src 'self' 'sha256-OdI56ZW769BKGaLghLr3uZVaaWfqyRwyccMiu8gXf0w=' 'sha256-D2blx2qCCtVP48luzhEjUKKIcmHy77Ma+9/c6fv8UGM=' "
     />
 
-	<title>Drift Playground</title>
-	<link rel="stylesheet" media="screen, projection" href="./dist/drift-basic.css">
-	<style type="text/css">
-		body {
-			font-family: Helvetica Neue, Arial, sans;
-			margin-top: 2em;
-			background: #FAFAFA;
-		}
+    <title>Drift Playground</title>
+    <link rel="stylesheet" media="screen, projection" href="./dist/drift-basic.css" />
+    <style type="text/css">
+      body {
+        font-family: Helvetica Neue, Arial, sans;
+        margin-top: 2em;
+        background: #fafafa;
+      }
 
-		.wrapper {
-			margin: 0 auto;
-			width: 860px;
-		}
+      .wrapper {
+        margin: 0 auto;
+        width: 860px;
+      }
 
-		.drift-demo-trigger {
-			width: 40%;
-			float: left;
-		}
+      .drift-demo-trigger {
+        width: 40%;
+        float: left;
+      }
 
-		.detail {
-			position: relative;
-			width: 55%;
-			margin-left: 5%;
-			float: left;
-		}
+      .detail {
+        position: relative;
+        width: 55%;
+        margin-left: 5%;
+        float: left;
+      }
 
-		h1 {
-			color: #013C4A;
-			margin-top: 1em;
-			margin-bottom: 1em;
-		}
+      h1 {
+        color: #013c4a;
+        margin-top: 1em;
+        margin-bottom: 1em;
+      }
 
-		p {
-			max-width: 32em;
-			margin-bottom: 1em;
-			color: #23637f;
-			line-height: 1.6em;
-		}
+      p {
+        max-width: 32em;
+        margin-bottom: 1em;
+        color: #23637f;
+        line-height: 1.6em;
+      }
 
-		p:last-of-type {
-			margin-bottom: 2em;
-		}
+      p:last-of-type {
+        margin-bottom: 2em;
+      }
 
-		a {
-			color: #00C0FA;
-		}
+      a {
+        color: #00c0fa;
+      }
 
-		.ix-link {
-			display: block;
-			margin-bottom: 3em;
-		}
+      .ix-link {
+        display: block;
+        margin-bottom: 3em;
+      }
 
-		@media (max-width: 900px) {
-			.wrapper {
-				text-align: center;
-				width: auto;
-			}
+      @media (max-width: 900px) {
+        .wrapper {
+          text-align: center;
+          width: auto;
+        }
 
-			.detail,
-			.drift-demo-trigger {
-				float: none;
-			}
+        .detail,
+        .drift-demo-trigger {
+          float: none;
+        }
 
-			.drift-demo-trigger {
-				max-width: 100%;
-				width: auto;
-				margin: 0 auto;
-			}
+        .drift-demo-trigger {
+          max-width: 100%;
+          width: auto;
+          margin: 0 auto;
+        }
 
-			.detail {
-				margin: 0;
-				width: auto;
-			}
+        .detail {
+          margin: 0;
+          width: auto;
+        }
 
-			p {
-				margin: 0 auto 1em;
-			}
+        p {
+          margin: 0 auto 1em;
+        }
 
-			.responsive-hint {
-				display: none;
-			}
+        .responsive-hint {
+          display: none;
+        }
 
-			.drift-bounding-box {
-				display: none;
-			}
-		}
-	</style>
-</head>
+        .drift-bounding-box {
+          display: none;
+        }
+      }
+    </style>
+  </head>
 
-<body>
-	<div class="wrapper">
-		<img class="drift-demo-trigger" data-zoom="http://assets.imgix.net/unsplash/lighthouse.jpg?w=1200&amp;ch=DPR&amp;dpr=2" src="http://assets.imgix.net/unsplash/lighthouse.jpg?w=400&amp;ch=DPR&amp;dpr=2">
+  <body>
+    <div class="wrapper">
+      <img
+        class="drift-demo-trigger"
+        data-zoom="http://assets.imgix.net/unsplash/lighthouse.jpg?w=1200&amp;ch=DPR&amp;dpr=2"
+        src="http://assets.imgix.net/unsplash/lighthouse.jpg?w=400&amp;ch=DPR&amp;dpr=2"
+      />
 
-		<div class="detail">
-			<section>
-				<h1>Drift Demo</h1>
-				<p>This is a demo of Drift, a simple, lightweight, no-dependencies JavaScript "zoom on hover" tool from
-					<a href="http://imgix.com">imgix</a>. Move your mouse over the image (or touch it) to see it in action.</p>
-				<p>This demo uses the simple included theme, but it's very easy to extend and customize to fit your needs. You can
-					<a href="https://github.com/imgix/drift">learn more and download it here</a>.</p>
-				<p class="responsive-hint">(Psst… try making your browser window smaller!)</p>
-			</section>
+      <div class="detail">
+        <section>
+          <h1>Drift Demo</h1>
+          <p>
+            This is a demo of Drift, a simple, lightweight, no-dependencies JavaScript "zoom on hover" tool from
+            <a href="http://imgix.com">imgix</a>. Move your mouse over the image (or touch it) to see it in action.
+          </p>
+          <p>
+            This demo uses the simple included theme, but it's very easy to extend and customize to fit your needs. You
+            can <a href="https://github.com/imgix/drift">learn more and download it here</a>.
+          </p>
+          <p class="responsive-hint">(Psst… try making your browser window smaller!)</p>
+        </section>
 
-			<a href="https://imgix.com" class="ix-link">
-				<img src="https://assets.imgix.net/presskit/imgix-presskit.pdf?page=3&amp;fm=png&amp;w=320&amp;dpr=2" width="160" height="60"
-				 alt="imgix">
-			</a>
-		</div>
-	</div>
+        <a href="https://imgix.com" class="ix-link">
+          <img
+            src="https://assets.imgix.net/presskit/imgix-presskit.pdf?page=3&amp;fm=png&amp;w=320&amp;dpr=2"
+            width="160"
+            height="60"
+            alt="imgix"
+          />
+        </a>
+      </div>
+    </div>
 
-	<script src="dist/Drift.js"></script>
-	<script>
-		new Drift(document.querySelector('.drift-demo-trigger'), {
-			paneContainer: document.querySelector('.detail'),
-			inlinePane: 900,
-			inlineOffsetY: -85,
-			containInline: true,
-			hoverBoundingBox: true
-		});
-	</script>
-</body>
-
+    <script src="dist/Drift.js"></script>
+    <script>
+      new Drift(document.querySelector(".drift-demo-trigger"), {
+        paneContainer: document.querySelector(".detail"),
+        inlinePane: 900,
+        inlineOffsetY: -85,
+        containInline: true,
+        hoverBoundingBox: true,
+      });
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,12 @@
 	<meta name="designer" content="imgix">
 	<meta name="developer" content="imgix">
 	<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,maximum-scale=1">
+	<!-- If CSP style policies, ensure SHA, nonce, or unsafe-inline are enabled -->
 	<meta http-equiv="Accept-CH" content="DPR, Width, Viewport-Width">
+	    <meta
+      http-equiv="Content-Security-Policy"
+      content="style-src 'self' 'sha256-W+PadZMOYbQi3EzR/NC+KcPx3bNLCz0OtfWwp+LK9b4=' 'sha256-OdI56ZW769BKGaLghLr3uZVaaWfqyRwyccMiu8gXf0w=' 'sha256-W+PadZMOYbQi3EzR/NC+KcPx3bNLCz0OtfWwp+LK9b4=' 'sha256-cG/+JJX3ZZs6snnMipxMnaYWATXBcyQw3vFWJF1zmAM='"
+    />
 
 	<title>Drift Playground</title>
 	<link rel="stylesheet" media="screen, projection" href="./dist/drift-basic.css">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Easily add \"zoom on hover\" functionality to your site's images. Lightweight, no-dependency JavaScript.",
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
-    "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)"
+    "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)",
+    "Luis Ball <lball@imgix.com> (https://github.com/luqven)"
   ],
   "main": "lib/Drift.js",
   "module": "es/Drift.js",

--- a/src/js/injectBaseStylesheet.js
+++ b/src/js/injectBaseStylesheet.js
@@ -55,13 +55,14 @@ export default function injectBaseStylesheet() {
     return;
   }
 
+  // create the injected styles
   const styleEl = document.createElement("style");
-  styleEl.type = "text/css";
   styleEl.classList = "drift-base-styles";
-
   styleEl.textContent = RULES;
-  const head = document.head;
 
+  // prepend them to the document head's first child
+  const head = document.head;
   const allHeadElements = head.getElementsByTagName("*");
-  allHeadElements.innerHTML = styleEl + allHeadElements.innerHTML;
+  const firstItem = allHeadElements.item(0);
+  firstItem.outerHTML = styleEl.outerHTML + firstItem.outerHTML;
 }


### PR DESCRIPTION
## Description

* Fix a bug where `getElementByTagName()` was attempting to access an attribute, `.innerHTML`, that was not defined.

* Instead updates stylesheet by using the `.item()` method for `HTMLCollections` to then access `.innerHTML`.

## Checklist
- [bug fix](x)

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [x] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!


## Steps to Test

Clone the repo, `npm run build`, and open `/index.html` in your default browser.

Related issue: [e.g. #603 ]

Code:

```diff
const allHeadElements = head.getElementsByTagName("*");
-  allHeadElements.innerHTML = styleEl + allHeadElements.innerHTML;
+  const styleTag = headElements.item(headElements.length - 1);
+  styleTag.innerHTML = styleEl.innerHTML + styleTag.innerHTML;
```

### Discussion

In future, Cypress testing (or the like) integration is recommended to catch this type of bugs. Hard to detect without browser testing.