### PR TITLE
fix: add postcss dependency to fix build error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,8 @@ To install all development dependencies, in the project's root directory, run
 npm install
 ```
 
+> Please note: the build process assumes Java is installed locally.
+
 Once you're configured, building the JavaScript from the command line is easy:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ To install all development dependencies, in the project's root directory, run
 npm install
 ```
 
-> Please note: the build process assumes Java is installed locally.
+**Please note: the build process assumes Java is installed locally.**
 
 Once you're configured, building the JavaScript from the command line is easy:
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "webpack": "4.46.0",
     "webpack-cli": "4.3.1",
     "webpack-closure-compiler": "2.1.6",
-    "yargs": "16.2.0"
+    "yargs": "16.2.0",
+    "postcss": "^8.1.0"
   },
   "dependencies": {},
   "browserslist": [


### PR DESCRIPTION
<!-- prettier-ignore-start -->
## Description

- This PR adds `postcss` library as a dependency, since it was missing and causing errors
- It also updated the contributing docs to reflect the need for Java to run build scripts.

<!-- prettier-ignore-end -->
