### PR TITLE
fix: revert directly modifying DOM over setAttribute

### DIFF
--- a/src/js/injectBaseStylesheet.js
+++ b/src/js/injectBaseStylesheet.js
@@ -57,11 +57,10 @@ export default function injectBaseStylesheet() {
 
   const styleEl = document.createElement("style");
   styleEl.type = "text/css";
-  styleEl.classList = "drift-base-styles";
+  styleEl.classList.add("drift-base-styles");
 
-  styleEl.textContent = RULES;
+  styleEl.appendChild(document.createTextNode(RULES));
+
   const head = document.head;
-
-  const allHeadElements = head.getElementsByTagName("*");
-  allHeadElements.innerHTML = styleEl + allHeadElements.innerHTML;
+  head.insertBefore(styleEl, head.firstChild);
 }


### PR DESCRIPTION
## Changes

- This PR addresses a [suggestion](https://github.com/imgix/drift/pull/605#discussion_r584831527) to revert back part of commit 62c51dc. 
- It fixes a bug where `getElementByTagName()` was attempting to access an attribute, `.innerHTML`, that was not defined.
- The commit in question was an attempt to fix a CSP issue.  You can find more on the discussion around how to best address the CSP issue [here](https://github.com/imgix/drift/pull/605#issuecomment-786824261). 