### PR TITLE
fix: remove inline styles individually

### DIFF
--- a/src/js/ZoomPane.js
+++ b/src/js/ZoomPane.js
@@ -243,7 +243,8 @@ export default class ZoomPane {
     removeClasses(this.el, this.closingClasses);
     removeClasses(this.el, this.inlineClasses);
 
-    this.el.style = "";
+    this.el.style.left = "";
+    this.el.style.top = "";
 
     // The window could have been resized above or below `inline`
     // limits since the ZoomPane was shown. Because of this, we


### PR DESCRIPTION
## Description

In #598 `element.setAttribute("style", "")` was changed to `element.style = ""` to fix a CSP issue. The latter is an assignment to a read-only property in Internet Explorer 11, that causes an error: `Assignment to read-only properties is not allowed in strict mode`

The fix implemented in this pull request is to simply clear out each of the affected style properties individually.