### PR TITLE
build: enable semantic release in all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ deploy:
   script:
     - npx semantic-release
   on:
-    branch: next
+    all_branches: true

--- a/package.json
+++ b/package.json
@@ -125,13 +125,13 @@
           "replacements": [
             {
               "files": [
-                "src/Drift.js"
+                "src/js/Drift.js"
               ],
-              "from": "this.VERSION = '.*'",
-              "to": "this.VERSION = '${nextRelease.version}'",
+              "from": "this.VERSION = \".*\"",
+              "to": "this.VERSION = \"${nextRelease.version}\"",
               "results": [
                 {
-                  "file": "src/Drift.js",
+                  "file": "src/js/Drift.js",
                   "hasChanged": true,
                   "numMatches": 1,
                   "numReplacements": 1


### PR DESCRIPTION
This PR changes the semantic-release replace plugin replace text
from a string to a regex. This is more reliable when trying to find the
string in the codebase to replace and in line with what's recommended by
the plugin authors. It also fixes the files directory, which was missing
the `js` subdirectory.

The PR also changes the travis deploy script to target all branches.
