### PR TITLE
feat: add passive listener option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ var options = {
 	boundingBoxContainer: document.body,
 	// If true, the events related to handleTouch use passive listeners in
 	// order to improve performance for touch devices.
-	handleTouch: false,
+	passive: false,
 };
 
 new Drift(document.querySelector('img'), options);

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ var options = {
 	touchBoundingBox: false,
 	// A DOM element to append the bounding box to.
 	boundingBoxContainer: document.body,
+	// If true, the events related to handleTouch use passive listeners in
+	// order to improve performance for touch devices.
+	handleTouch: false,
 };
 
 new Drift(document.querySelector('img'), options);

--- a/src/js/Drift.js
+++ b/src/js/Drift.js
@@ -70,6 +70,9 @@ export default class Drift {
     const touchBoundingBox = options["touchBoundingBox"] || false;
     // A DOM element to append the bounding box to.
     const boundingBoxContainer = options["boundingBoxContainer"] || document.body;
+    // If true, the events related to handleTouch use passive listeners in
+    // order to improve performance for touch devices.
+    const passive = options["passive"] || false;
 
     if (inlinePane !== true && !isDOMElement(paneContainer)) {
       throw new TypeError("`paneContainer` must be a DOM element when `inlinePane !== true`");
@@ -98,6 +101,7 @@ export default class Drift {
       hoverBoundingBox,
       touchBoundingBox,
       boundingBoxContainer,
+      passive,
     };
 
     if (this.settings.injectBaseStyles) {
@@ -152,6 +156,7 @@ export default class Drift {
       namespace: this.settings.namespace,
       zoomFactor: this.settings.zoomFactor,
       boundingBoxContainer: this.settings.boundingBoxContainer,
+      passive: this.settings.passive,
     });
   }
 

--- a/src/js/Trigger.js
+++ b/src/js/Trigger.js
@@ -22,6 +22,7 @@ export default class Trigger {
       namespace = null,
       zoomFactor = throwIfMissing(),
       boundingBoxContainer = throwIfMissing(),
+      passive = false,
     } = options;
 
     this.settings = {
@@ -38,6 +39,7 @@ export default class Trigger {
       namespace,
       zoomFactor,
       boundingBoxContainer,
+      passive,
     };
 
     if (this.settings.hoverBoundingBox || this.settings.touchBoundingBox) {
@@ -76,14 +78,15 @@ export default class Trigger {
     this.settings.el.addEventListener("mouseleave", this._hide, false);
     this.settings.el.addEventListener("mousemove", this._handleMovement, false);
 
+    const isPassive = { passive: this.settings.passive };
     if (this.settings.handleTouch) {
-      this.settings.el.addEventListener("touchstart", this._handleEntry, false);
+      this.settings.el.addEventListener("touchstart", this._handleEntry, isPassive);
       this.settings.el.addEventListener("touchend", this._hide, false);
-      this.settings.el.addEventListener("touchmove", this._handleMovement, false);
+      this.settings.el.addEventListener("touchmove", this._handleMovement, isPassive);
     } else {
-      this.settings.el.addEventListener("touchstart", this._preventDefault, false);
+      this.settings.el.addEventListener("touchstart", this._preventDefault, isPassive);
       this.settings.el.addEventListener("touchend", this._preventDefault, false);
-      this.settings.el.addEventListener("touchmove", this._preventDefault, false);
+      this.settings.el.addEventListener("touchmove", this._preventDefault, isPassive);
     }
   }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -56,6 +56,7 @@ export function triggerOptions() {
     namespace: null,
     zoomFactor: 3,
     boundingBoxContainer: document.body,
+    passive: false,
   };
 }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,6 +25,7 @@ export function defaultDriftConfig() {
     hoverBoundingBox: false,
     touchBoundingBox: false,
     boundingBoxContainer: document.body,
+    passive: false,
   };
 }
 

--- a/test/testTrigger.js
+++ b/test/testTrigger.js
@@ -113,4 +113,27 @@ describe("Trigger", () => {
     trigger.settings.el.dispatchEvent(event);
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it("uses passive listeners for touchstart on mobile when passive is set to true", () => {
+    const opts = triggerOptions();
+    opts.passive = true;
+
+    const trigger = new Trigger(opts);
+
+    const event = new Event("touchstart", { cancelable: true });
+
+    trigger.settings.el.dispatchEvent(event);
+    expect(event.defaultPrevented).toBeFalse();
+  });
+
+  it("does not use passive listeners for touchstart on mobile when passive is set to false", () => {
+    const opts = triggerOptions();
+    opts.passive = false;
+
+    const trigger = new Trigger(opts);
+    const event = new Event("touchstart", { cancelable: true });
+
+    trigger.settings.el.dispatchEvent(event);
+    expect(event.defaultPrevented).toBeTrue();
+  });
 });


### PR DESCRIPTION
## Description

- This PR introduces a new option: `passive` to remove the warning of [Lighthouse](https://developers.google.com/web/tools/lighthouse/) and improve the performance for mobile on touch move and touch start events.
- With passive listeners, [`event.preventDefault`](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) will never be called

### New Feature

- [X] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [X] Run unit tests to ensure all existing tests are still passing
- [X] Add new passing unit tests to cover the code introduced by your PR
- [X] Update the readme
- [X] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [X] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Simple example:
```js
// full example available in the sandbox below
const [img, paneContainer] = document.querySelectorAll(".wrapper > *");
new Drift(img, {
  paneContainer,
  passive: true
});
```

Steps:

1. Open this [sandbox](https://codesandbox.io/s/compassionate-wildflower-zbpye?file=/index.html)
2. Click on _open in new window_ or directly [here](https://zbpye.csb.app/). with Chrome. 
3. Inspect the page, open the Lighthouse tab and click on _perfomance_ and _generate perfomance_.
![image](https://user-images.githubusercontent.com/41640423/129120866-0fc59745-aa1f-4dc3-a459-56589d94ede6.png)
4.  The error is gone :smile: 

| Before | ![image](https://user-images.githubusercontent.com/41640423/129120335-0f023869-dbe5-45b8-ae34-44d8fd630d13.png) |
|---|---|
| After | ![image](https://user-images.githubusercontent.com/41640423/129120404-e474cc00-1e6d-427c-b7f7-03d7c070de5b.png) |

:warning: Although Chrome doesn't warning you when you use:

```js
domeDomElem.addEventListener("touchstart", aSlowFunction, {passive: false})
```

The  point of this PR is to have the opportunity to use `{passive: true}`

resolve #640 