### PR TITLE
build(travis): pin node v17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 jobs:
   include:
-  - node: stable
-    env: NODE_OPTIONS=--openssl-legacy-provider
+    - node: 17
+      env: NODE_OPTIONS=--openssl-legacy-provider
 install:
   - npm install
 script:


### PR DESCRIPTION
This commit fixes an issue where Travis node lts was set to 18. This caused build errors on CI. A future commit should reverse this change once we've figured out if the issue is on Travis's end or ours.